### PR TITLE
Fix syntax error in dictionary

### DIFF
--- a/PyPedal/pyp_newclasses.py
+++ b/PyPedal/pyp_newclasses.py
@@ -621,11 +621,11 @@ class NewPedigree:
             merged_pedname = 'Merged Pedigree: %s + %s' % \
                              (self.kw['pedname'], other.kw['pedname'])
             new_options = {
-                'messages': self.kw['messages']
-                'pedname': merged_pedname
-                'renumber': 1
-                'pedfile': filename
-                'pedformat': self.kw['pedformat']
+                'messages': self.kw['messages'],
+                'pedname': merged_pedname,
+                'renumber': 1,
+                'pedfile': filename,
+                'pedformat': self.kw['pedformat'],
             }
             # Load the new pedigree and return it.
             try:


### PR DESCRIPTION
Fixes:
byte-compiling build/bdist.linux-x86_64/egg/PyPedal/pyp_newclasses.py to pyp_newclasses.pyc
  File "build/bdist.linux-x86_64/egg/PyPedal/pyp_newclasses.py", line 625
    'pedname': merged_pedname
            ^
SyntaxError: invalid syntax